### PR TITLE
Fix no cif file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv
 data
 log
+__pycache__

--- a/get_sasbdb_entries.py
+++ b/get_sasbdb_entries.py
@@ -131,8 +131,8 @@ def download_ciffile(code):
 
     logging.info('Downloading the SAS CIF file for {}'.format(code))
     request_data = make_request(url)
-    request_data.encoding = 'utf-8'
     if request_data is not None:
+        request_data.encoding = 'utf-8'
         with open('data/{}.sascif'.format(code), 'w') as outfile:
             logging.info('Saving the SAS CIF file for {} in the data folder - {}.sascif'.format(code, code))
             outfile.write(request_data.text)


### PR DESCRIPTION
Fix the encoding error when there is no cif file to download.

Add `__pycache__` to the `.gitignore` file.